### PR TITLE
support PD disaggregation

### DIFF
--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -102,7 +102,6 @@ def parse_args():
     parser.add_argument(
         "--routing-logic",
         type=str,
-        # required=True,
         choices=["roundrobin", "session"],
         help="The routing logic to use",
     )
@@ -229,14 +228,12 @@ def parse_args():
     parser.add_argument(
         "--routing-logic-prefill",
         type=str,
-        # required=True,
         choices=["roundrobin", "session"],
         help="The routing logic for prefill to use",
     )    
     parser.add_argument(
         "--routing-logic-decode",
         type=str,
-        # required=True,
         choices=["roundrobin", "session"],
         help="The routing logic for decode to use",
     )        

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -29,7 +29,7 @@ except ImportError:
 # --- Argument Parsing and Initialization ---
 def validate_args(args):
     if args.service_discovery == "static":
-        if args.static_backends or (args.static_prefill_backends is None and args.static_decode_backends is None) is None:
+        if args.static_backends is None and (args.static_prefill_backends is None or args.static_decode_backends is None):
             raise ValueError(
                 "Static backends must be provided when using static service discovery."
             )
@@ -37,6 +37,10 @@ def validate_args(args):
             raise ValueError(
                 "Static models must be provided when using static service discovery."
             )
+    if args.routing_logic is None and (args.routing_logic_prefill is None or args.routing_logic_decode is None):
+        raise ValueError(
+            "routing logic must be provided."
+        )        
     if args.service_discovery == "k8s" and args.k8s_port is None:
         raise ValueError("K8s port must be provided when using K8s service discovery.")
     if args.routing_logic == "session" and args.session_key is None:

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -29,7 +29,7 @@ except ImportError:
 # --- Argument Parsing and Initialization ---
 def validate_args(args):
     if args.service_discovery == "static":
-        if args.static_backends is None:
+        if args.static_backends or (args.static_prefill_backends is None and args.static_decode_backends is None) is None:
             raise ValueError(
                 "Static backends must be provided when using static service discovery."
             )
@@ -98,7 +98,7 @@ def parse_args():
     parser.add_argument(
         "--routing-logic",
         type=str,
-        required=True,
+        # required=True,
         choices=["roundrobin", "session"],
         help="The routing logic to use",
     )
@@ -203,6 +203,39 @@ def parse_args():
         choices=["critical", "error", "warning", "info", "debug", "trace"],
         help="Log level for uvicorn. Default is 'info'.",
     )
+
+    # the following parameters are for PD disaggregation support
+    parser.add_argument(
+        "--enable-pd", 
+        action="store_true", 
+        help="enable PD disaggregation"
+    )
+    parser.add_argument(
+        "--static-prefill-backends",
+        type=str,
+        default=None,
+        help="The URLs of static prefill backends, separated by commas. E.g., http://localhost:8000,http://localhost:8002",
+    )
+    parser.add_argument(
+        "--static-decode-backends",
+        type=str,
+        default=None,
+        help="The URLs of static decode backends, separated by commas. E.g., http://localhost:8001,http://localhost:8003",
+    )    
+    parser.add_argument(
+        "--routing-logic-prefill",
+        type=str,
+        # required=True,
+        choices=["roundrobin", "session"],
+        help="The routing logic for prefill to use",
+    )    
+    parser.add_argument(
+        "--routing-logic-decode",
+        type=str,
+        # required=True,
+        choices=["roundrobin", "session"],
+        help="The routing logic for decode to use",
+    )        
 
     args = parser.parse_args()
     validate_args(args)

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -186,8 +186,8 @@ def initialize_routing_logic(
         logger.info(f"Initializing session-based routing logic with kwargs: {kwargs}")
         return SessionRouter(kwargs.get("session_key"))
     elif kwargs.get("routing_logic_prefill") is not None and kwargs.get("routing_logic_decode") is not None:
-        prefill_router = None
-        decode_router = None
+        global prefill_router
+        global decode_router
         if kwargs.get("routing_logic_prefill") == RoutingLogic.ROUND_ROBIN:
             prefill_router = RoundRobinRouter()
         elif kwargs.get("routing_logic_prefill") == RoutingLogic.SESSION_BASED:

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -87,6 +87,7 @@ class StaticServiceDiscoveryPD(StaticServiceDiscovery):
     def __init__(self, urls: List[str], models: List[str], prefill_urls: List[str], decode_urls: List[str]):
         super().__init__(urls, models)
 
+        global _global_enable_pd
         _global_enable_pd = True
 
         self.prefill_urls = prefill_urls

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -173,7 +173,6 @@ async def route_general_request(request: Request, endpoint: str):
         )
 
     logger.debug(f"Routing request {request_id} for model: {requested_model}")
-
     if not is_pd_enabled():
         server_url = request.app.state.router.route_request(
             endpoints, engine_stats, request_stats, request
@@ -211,10 +210,9 @@ async def route_general_request(request: Request, endpoint: str):
         )
         prefill_req_data = request_json.copy()
         prefill_req_data['max_tokens'] = 1
-        prefill_req_data['max_completion_tokens'] = 1
+        prefill_req_data['max_completion_tokens'] = 1      
         response = await request.app.state.httpx_client_wrapper().post(
-            endpoint,
-            base_url=prefill_url,
+            prefill_url + endpoint,
             json=prefill_req_data)
         response.raise_for_status()        
 

--- a/src/vllm_router/stats/log_stats.py
+++ b/src/vllm_router/stats/log_stats.py
@@ -33,7 +33,6 @@ def log_stats(app: FastAPI, interval: int = 10):
         interval (int): The interval in seconds at which statistics are logged.
             Default is 10 seconds.
     """
-
     while True:
         time.sleep(interval)
         logstr = "\n" + "=" * 50 + "\n"

--- a/src/vllm_router/stats/log_stats.py
+++ b/src/vllm_router/stats/log_stats.py
@@ -33,6 +33,7 @@ def log_stats(app: FastAPI, interval: int = 10):
         interval (int): The interval in seconds at which statistics are logged.
             Default is 10 seconds.
     """
+    
     while True:
         time.sleep(interval)
         logstr = "\n" + "=" * 50 + "\n"


### PR DESCRIPTION
1. start prefill and decode vllm instances
2. run command example:
`python3 -m vllm_router.app --port 8000  --service-discovery static  --static-prefill-backends "http://localhost:7800,http://localhost:7802"  --static-decode-backends "http://localhost:7801,http://localhost:7803"  --static-models "mistralai/Mistral-7B-Instruct-v0.2,mistralai/Mistral-7B-Instruct-v0.2,mistralai/Mistral-7B-Instruct-v0.2,mistralai/Mistral-7B-Instruct-v0.2"  --log-stats  --log-stats-interval 10  --engine-stats-interval 10  --request-stats-window 10  --request-stats-window 10  --routing-logic-prefill roundrobin  --routing-logic-decode roundrobin  --enable-pd`